### PR TITLE
Fix empty `raw` in `Ace` object

### DIFF
--- a/src/Sddl.Parser/Ace.cs
+++ b/src/Sddl.Parser/Ace.cs
@@ -20,6 +20,8 @@ namespace Sddl.Parser
         {
             var parts = ace.Split(SeparatorToken);
 
+            Raw = ace;
+
             if (parts.Length < 6)
             {
                 // ERROR Ace have incorrect format - less parts than 6.


### PR DESCRIPTION
The field `raw` in the object `Ace` is always `NULL` since no value is assigned to it anywhere.
This PR fix this.