### PR TITLE
Add equal operator for `Ace` object

### DIFF
--- a/src/Sddl.Parser/Ace.cs
+++ b/src/Sddl.Parser/Ace.cs
@@ -408,38 +408,31 @@ namespace Sddl.Parser
             return sb.ToString();
         }
 
+        public override bool Equals(object obj)
+        {
+            return obj is Ace ace &&
+                   Raw == ace.Raw &&
+                   AceType == ace.AceType &&
+                   EqualityComparer<string[]>.Default.Equals(AceFlags, ace.AceFlags) &&
+                   EqualityComparer<string[]>.Default.Equals(Rights, ace.Rights) &&
+                   ObjectGuid == ace.ObjectGuid &&
+                   InheritObjectGuid == ace.InheritObjectGuid &&
+                   AceSid == ace.AceSid;
+        }
+
         public static bool operator== (Ace ace0, Ace ace1)
         {
-            bool isTypeEqual, areFlagsEqual, areRightsEqual, isObjectGuidEqual, isInheritObjectGuid;
-
-            isTypeEqual = ace0.AceType == ace1.AceType;
-            isObjectGuidEqual = ace0.ObjectGuid == ace1.ObjectGuid;
-            isInheritObjectGuid = ace0.InheritObjectGuid == ace1.InheritObjectGuid;
-
-            if (ace0.AceFlags != null && ace1.AceFlags != null)
-            {
-                areFlagsEqual = !ace0.AceFlags.Except(ace1.AceFlags).Any() && !ace1.AceFlags.Except(ace0.AceFlags).Any();
-            }
+            if (ace0 is null && ace1 is null)
+                return true;
+            else if (ace0 is null || ace1 is null)
+                return false;
             else
-            {
-                areFlagsEqual = ace0.AceFlags == null && ace1.AceFlags == null;
-            }
-
-            if (ace0.Rights != null && ace1.Rights != null)
-            {
-                areRightsEqual = !ace0.Rights.Except(ace1.Rights).Any() && !ace1.Rights.Except(ace0.Rights).Any();
-            }
-            else
-            {
-                areRightsEqual = ace0.Rights == null && ace1.Rights == null;
-            }
-
-            return isTypeEqual && areFlagsEqual && areRightsEqual && isObjectGuidEqual && isInheritObjectGuid;
+                return ace0.Equals(ace1);
         }
 
         public static bool operator!= (Ace ace0, Ace ace1)
         {
-            return !(ace0 == ace1);
+            return !!(ace0 == ace1);
         }
     }
 }

--- a/src/Sddl.Parser/Ace.cs
+++ b/src/Sddl.Parser/Ace.cs
@@ -407,5 +407,39 @@ namespace Sddl.Parser
 
             return sb.ToString();
         }
+
+        public static bool operator== (Ace ace0, Ace ace1)
+        {
+            bool isTypeEqual, areFlagsEqual, areRightsEqual, isObjectGuidEqual, isInheritObjectGuid;
+
+            isTypeEqual = ace0.AceType == ace1.AceType;
+            isObjectGuidEqual = ace0.ObjectGuid == ace1.ObjectGuid;
+            isInheritObjectGuid = ace0.InheritObjectGuid == ace1.InheritObjectGuid;
+
+            if (ace0.AceFlags != null && ace1.AceFlags != null)
+            {
+                areFlagsEqual = !ace0.AceFlags.Except(ace1.AceFlags).Any() && !ace1.AceFlags.Except(ace0.AceFlags).Any();
+            }
+            else
+            {
+                areFlagsEqual = ace0.AceFlags == null && ace1.AceFlags == null;
+            }
+
+            if (ace0.Rights != null && ace1.Rights != null)
+            {
+                areRightsEqual = !ace0.Rights.Except(ace1.Rights).Any() && !ace1.Rights.Except(ace0.Rights).Any();
+            }
+            else
+            {
+                areRightsEqual = ace0.Rights == null && ace1.Rights == null;
+            }
+
+            return isTypeEqual && areFlagsEqual && areRightsEqual && isObjectGuidEqual && isInheritObjectGuid;
+        }
+
+        public static bool operator!= (Ace ace0, Ace ace1)
+        {
+            return !(ace0 == ace1);
+        }
     }
 }

--- a/src/Sddl.Parser/Ace.cs
+++ b/src/Sddl.Parser/Ace.cs
@@ -432,7 +432,7 @@ namespace Sddl.Parser
 
         public static bool operator!= (Ace ace0, Ace ace1)
         {
-            return !!(ace0 == ace1);
+            return !(ace0 == ace1);
         }
     }
 }

--- a/src/Sddl.Parser/Acl.cs
+++ b/src/Sddl.Parser/Acl.cs
@@ -98,5 +98,28 @@ namespace Sddl.Parser
 
             return sb.ToString();
         }
+
+        public override bool Equals(object obj)
+        {
+            return obj is Acl acl &&
+                   Raw == acl.Raw &&
+                   EqualityComparer<string[]>.Default.Equals(Flags, acl.Flags) &&
+                   EqualityComparer<Ace[]>.Default.Equals(Aces, acl.Aces);
+        }
+
+        public static bool operator== (Acl acl0, Acl acl1)
+        {
+            if (acl0 is null && acl1 is null)
+                return true;
+            else if (acl0 is null || acl1 is null)
+                return false;
+            else
+                return acl0.Equals(acl1);
+        }
+
+        public static bool operator!= (Acl acl0, Acl acl1)
+        {
+            return !(acl0 == acl1);
+        }
     }
 }

--- a/src/Sddl.Parser/Sddl.cs
+++ b/src/Sddl.Parser/Sddl.cs
@@ -98,5 +98,30 @@ namespace Sddl.Parser
 
             return sb.ToString();
         }
+
+        public override bool Equals(object obj)
+        {
+            return obj is Sddl sddl &&
+                   Raw == sddl.Raw &&
+                   Owner == sddl.Owner &&
+                   Group == sddl.Group &&
+                   Dacl == sddl.Dacl &&
+                   Sacl == sddl.Sacl;
+        }
+
+        public static bool operator== (Sddl sddl0, Sddl sddl1)
+        {
+            if (sddl0 is null && sddl1 is null)
+                return true;
+            else if (sddl0 is null || sddl1 is null)
+                return false;
+            else
+                return sddl0.Equals(sddl1);
+        }
+
+        public static bool operator!= (Sddl sddl0, Sddl sddl1)
+        {
+            return !(sddl0 == sddl1);
+        }
     }
 }

--- a/src/Sddl.Parser/Sid.cs
+++ b/src/Sddl.Parser/Sid.cs
@@ -204,5 +204,27 @@ namespace Sddl.Parser
         {
             return Alias.ToString();
         }
+
+        public override bool Equals(object obj)
+        {
+            return obj is Sid sid &&
+                   Raw == sid.Raw &&
+                   Alias == sid.Alias;
+        }
+
+        public static bool operator== (Sid sid0, Sid sid1)
+        {
+            if (sid0 is null && sid1 is null)
+                return true;
+            else if (sid0 is null || sid1 is null)
+                return false;
+            else
+                return sid0.Equals(sid1);
+        }
+
+        public static bool operator!= (Sid sid0, Sid sid1)
+        {
+            return !(sid0 == sid1);
+        }
     }
 }

--- a/test/Sddl.Parser.Tests/SddlTests.cs
+++ b/test/Sddl.Parser.Tests/SddlTests.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using Xunit;
 


### PR DESCRIPTION
I thought that it could be a good idea - and actually I need it - to provide the equal operator to compare Ace objects.