### PR TITLE
Initialize the `Errors` member of the Acm class

### DIFF
--- a/src/Sddl.Parser/Acm.cs
+++ b/src/Sddl.Parser/Acm.cs
@@ -6,7 +6,7 @@ namespace Sddl.Parser
     public abstract class Acm
     {
         public bool IsValid => Errors.Any() == false;
-        public List<Error> Errors = new List<Error>();
+        public List<Error> Errors { get; } = new List<Error>();
 
         protected void Report(Error error) => Errors.Add(error);
     }

--- a/src/Sddl.Parser/Acm.cs
+++ b/src/Sddl.Parser/Acm.cs
@@ -6,7 +6,7 @@ namespace Sddl.Parser
     public abstract class Acm
     {
         public bool IsValid => Errors.Any() == false;
-        public List<Error> Errors { get; }
+        public List<Error> Errors = new List<Error>();
 
         protected void Report(Error error) => Errors.Add(error);
     }


### PR DESCRIPTION
Not sure about this, it's maybe not the right thing to do but if this
field is not initialized when an error occurs we got an exception
because `Errors` is not set to an instance of an object.

Let me know what you think about that.