### PR TITLE
Fix Match.OneByPrefix()

### DIFF
--- a/src/Sddl.Parser/Ace.cs
+++ b/src/Sddl.Parser/Ace.cs
@@ -123,7 +123,7 @@ namespace Sddl.Parser
         /// <summary>
         /// A dictionary of ace type strings as defined in https://msdn.microsoft.com/en-us/library/windows/desktop/aa374928(v=vs.85).aspx#ace_types
         /// </summary>
-        internal static Dictionary<string, string> AceTypesDict = new Dictionary<string, string>
+        internal static SortedDictionary<string, string> AceTypesDict = new SortedDictionary<string, string>(new StringLengthComparer())
         {
             { "A", "ACCESS_ALLOWED" },
             { "D", "ACCESS_DENIED" },

--- a/src/Sddl.Parser/Match.cs
+++ b/src/Sddl.Parser/Match.cs
@@ -45,7 +45,15 @@ namespace Sddl.Parser
         {
             foreach (var kv in tokensToLabels)
             {
-                if (input.StartsWith(kv.Key))
+                if (input.Length <= 2)
+                {
+                    if (input == kv.Key)
+                    {
+                        reminder = null;
+                        return kv.Value;
+                    }
+                }
+                else if (input.StartsWith(kv.Key))
                 {
                     reminder = SubstituteEmptyWithNull(input.Substring(kv.Key.Length));
                     return kv.Value;

--- a/src/Sddl.Parser/Match.cs
+++ b/src/Sddl.Parser/Match.cs
@@ -45,15 +45,7 @@ namespace Sddl.Parser
         {
             foreach (var kv in tokensToLabels)
             {
-                if (input.Length <= 2)
-                {
-                    if (input == kv.Key)
-                    {
-                        reminder = null;
-                        return kv.Value;
-                    }
-                }
-                else if (input.StartsWith(kv.Key))
+                if (input.StartsWith(kv.Key))
                 {
                     reminder = SubstituteEmptyWithNull(input.Substring(kv.Key.Length));
                     return kv.Value;

--- a/src/Sddl.Parser/StringLengthComparer.cs
+++ b/src/Sddl.Parser/StringLengthComparer.cs
@@ -2,7 +2,7 @@
 
 namespace Sddl.Parser
 {
-    public class StringLengthComparer : IComparer<string>
+    internal class StringLengthComparer : IComparer<string>
     {
         public int Compare(string x, string y)
         {

--- a/src/Sddl.Parser/StringLengthComparer.cs
+++ b/src/Sddl.Parser/StringLengthComparer.cs
@@ -1,0 +1,21 @@
+﻿using System.Collections.Generic;
+
+namespace Sddl.Parser
+{
+    public class StringLengthComparer : IComparer<string>
+    {
+        public int Compare(string x, string y)
+        {
+            int result = x.Length.CompareTo(y.Length);
+
+            if (result == 0)
+            {
+                return x.CompareTo(y);
+            }
+            else
+            {
+                return -result;
+            }
+        }
+    }
+}


### PR DESCRIPTION
When an Ace type or flag first letter is the same as another Ace type
or flag which is one letter long - e.g.: `AU` and `A` - depending on the
order in which the iterator returns its KeyValuePair the
Match.OneByPrefix() function is likely to return the wrong type/flag
and load `reminder` with a non-null value which provoke something like
`Unknown(AU)` even if we obviously know what `AU` is.