### PR TITLE
Fix Sddl.ToString function and tests

### DIFF
--- a/src/Sddl.Parser/Sddl.cs
+++ b/src/Sddl.Parser/Sddl.cs
@@ -93,7 +93,7 @@ namespace Sddl.Parser
             if (Sacl != null)
             {
                 sb.AppendLineEnv($"{nameof(Sacl)}:");
-                sb.AppendIndentEnv(Dacl.ToString());
+                sb.AppendIndentEnv(Sacl.ToString());
             }
 
             return sb.ToString();

--- a/test/Sddl.Parser.Tests/SddlTests.cs
+++ b/test/Sddl.Parser.Tests/SddlTests.cs
@@ -162,37 +162,27 @@ Dacl:
     Rights:
       FILE_ALL
 Sacl:
-  Flags: PROTECTED, AUTO_INHERITED
+  Flags: AUTO_INHERITED
   Ace[00]
-    AceSid: Guests
-    AceType: ACCESS_DENIED
-    AceFlags: OBJECT_INHERIT, CONTAINER_INHERIT
-    Rights:
-      FILE_ALL
-  Ace[01]
-    AceSid: Administrators
-    AceType: ACCESS_ALLOWED
-    AceFlags: OBJECT_INHERIT, CONTAINER_INHERIT
-    Rights:
-      FILE_ALL
-  Ace[02]
-    AceSid: Creator Owner
-    AceType: ACCESS_ALLOWED
-    AceFlags: OBJECT_INHERIT, CONTAINER_INHERIT, INHERIT_ONLY
-    Rights:
-      FILE_ALL
-  Ace[03]
-    AceSid: Local System
-    AceType: ACCESS_ALLOWED
-    AceFlags: OBJECT_INHERIT, CONTAINER_INHERIT
-    Rights:
-      FILE_ALL
-  Ace[04]
     AceSid: Users
-    AceType: ACCESS_ALLOWED
-    AceFlags: OBJECT_INHERIT, CONTAINER_INHERIT
+    AceType: AUDIT
+    AceFlags: OBJECT_INHERIT, CONTAINER_INHERIT, NO_PROPAGATE, AUDIT_FAILURE
     Rights:
-      FILE_ALL
+      READ_PROPERTY
+      DELETE_TREE
+      STANDARD_DELETE
+      WRITE_DAC
+  Ace[01]
+    AceSid: Users
+    AceType: AUDIT
+    AceFlags: OBJECT_INHERIT, CONTAINER_INHERIT, NO_PROPAGATE, AUDIT_SUCCESS
+    Rights:
+      CREATE_CHILD
+      SELF_WRITE
+      READ_PROPERTY
+      DELETE_TREE
+      LIST_OBJECT
+      STANDARD_DELETE
 "
                 };
 
@@ -268,68 +258,17 @@ Dacl:
       READ_CONTROL
 Sacl:
   Ace[00]
-    AceSid: Local System
-    AceType: ACCESS_ALLOWED
+    AceSid: Everyone
+    AceType: AUDIT
+    AceFlags: AUDIT_SUCCESS, AUDIT_FAILURE
     Rights:
-      READ_PROPERTY
+      WRITE_DAC
+      WRITE_OWNER
+      STANDARD_DELETE
       WRITE_PROPERTY
       CREATE_CHILD
       DELETE_CHILD
-      LIST_CHILDREN
-      READ_CONTROL
-      WRITE_OWNER
-      WRITE_DAC
-      STANDARD_DELETE
       SELF_WRITE
-  Ace[01]
-    AceSid: Domain Admins
-    AceType: ACCESS_ALLOWED
-    Rights:
-      READ_PROPERTY
-      WRITE_PROPERTY
-      CREATE_CHILD
-      DELETE_CHILD
-      LIST_CHILDREN
-      READ_CONTROL
-      WRITE_OWNER
-      WRITE_DAC
-      STANDARD_DELETE
-      SELF_WRITE
-  Ace[02]
-    AceSid: Account Operators
-    AceType: OBJECT_ACCESS_ALLOWED
-    Rights:
-      CREATE_CHILD
-      DELETE_CHILD
-    ObjectGuid: bf967aba-0de6-11d0-a285-00aa003049e2
-  Ace[03]
-    AceSid: Account Operators
-    AceType: OBJECT_ACCESS_ALLOWED
-    Rights:
-      CREATE_CHILD
-      DELETE_CHILD
-    ObjectGuid: bf967a9c-0de6-11d0-a285-00aa003049e2
-  Ace[04]
-    AceSid: Account Operators
-    AceType: OBJECT_ACCESS_ALLOWED
-    Rights:
-      CREATE_CHILD
-      DELETE_CHILD
-    ObjectGuid: 6da8a4ff-0e52-11d0-a286-00aa003049e2
-  Ace[05]
-    AceSid: Print Operators
-    AceType: OBJECT_ACCESS_ALLOWED
-    Rights:
-      CREATE_CHILD
-      DELETE_CHILD
-    ObjectGuid: bf967aa8-0de6-11d0-a285-00aa003049e2
-  Ace[06]
-    AceSid: Authenticated Users
-    AceType: ACCESS_ALLOWED
-    Rights:
-      READ_PROPERTY
-      LIST_CHILDREN
-      READ_CONTROL
 "
                 };
             }


### PR DESCRIPTION
This function was printing the DACL twice instead of the DACL then
the SACL.

Note that the PR #13 must be merged first in order to make the tests pass.