### PR TITLE
 Fix ACE's equality

### DIFF
--- a/src/Sddl.Parser/Ace.cs
+++ b/src/Sddl.Parser/Ace.cs
@@ -412,8 +412,8 @@ namespace Sddl.Parser
         {
             return obj is Ace ace &&
                    AceType == ace.AceType &&
-                   ((AceFlags is null && ace.AceFlags is null) || (!(AceFlags is null) && !(ace.AceFlags is null) && AceFlags.Except(ace.AceFlags).Count() == 0)) &&
-                   ((Rights is null && ace.Rights is null) || (!(Rights is null) && !(ace.Rights is null) && Rights.Except(ace.Rights).Count() == 0)) &&
+                   ((AceFlags is null && ace.AceFlags is null) || (!(AceFlags is null) && !(ace.AceFlags is null) && AceFlags.Except(ace.AceFlags).Count() == 0 && ace.AceFlags.Except(AceFlags).Count() == 0)) &&
+                   ((Rights is null && ace.Rights is null) || (!(Rights is null) && !(ace.Rights is null) && Rights.Except(ace.Rights).Count() == 0 && ace.Rights.Except(Rights).Count() == 0)) &&
                    ObjectGuid == ace.ObjectGuid &&
                    InheritObjectGuid == ace.InheritObjectGuid &&
                    AceSid == ace.AceSid;

--- a/test/Sddl.Parser.Tests/SddlTests.cs
+++ b/test/Sddl.Parser.Tests/SddlTests.cs
@@ -419,6 +419,30 @@ Sacl:
                     "O:DAG:DAD:(OA;;CCDC;bf967aa8-0de6-11d0-a285-00aa003049e2;;PO)(A;;RPWPCCDCLCRCWOWDSDSW;;;SY)(A;;RPLCRC;;;AU)S:(AU;SAFA;WDWOSDWPCCDCSW;;;WD)",
                     "O:DAG:DAD:(A;;RPWPCCDCLCRCWOWDSDSW;;;SY)(OA;;CCDC;bf967aa8-0de6-11d0-a285-00aa003049e2;;PO)(A;;RPLCRC;;;AU)S:(AU;SAFA;WDWOSDWPCCDCSW;;;WD)"
                 };
+
+                yield return new object[]
+                {
+                    "O:DAG:DAD:(AU;SAFA;WDWOSDWPCCDCSW;;;WD)",
+                    "O:DAG:DAS:(AU;SAFA;WDWOSDWPCCDCSW;;;WD)"
+                };
+
+                yield return new object[]
+                {
+                    "O:DAG:DAD:(AU;SAFA;WDWOSDWPCCDCSW;;;WD)",
+                    "O:DAG:DAD:(AU;SAFA;WDWOSDWPCCSW;;;WD)"
+                };
+
+                yield return new object[]
+                {
+                    "O:DAG:DAD:(AU;SAFA;WDWOSDWPCCSW;;;WD)",
+                    "O:DAG:DAD:(AU;SAFA;WDWOSDWPCCDCSW;;;WD)"
+                };
+
+                yield return new object[]
+                {
+                    "O:DAG:DAD:(AU;SAFA;WDWOSDWPDCSW;;;WD)",
+                    "O:DAG:DAD:(AU;SAFA;WDWOSDWPCCSW;;;WD)"
+                };
             }
         }
     }


### PR DESCRIPTION
This need to be fixed since as the doc says
(https://docs.microsoft.com/en-us/dotnet/api/system.linq.enumerable.except?view=netframework-4.8)
the `except()` method output a collection of things that are present in
the first and not in not second collection but if we have something in
the second collection which is not in the first one, the `except()` method
returns nothing at all.
Following that, the implementation of the ACE's equality is wrong

This commit fix that by adding a second call to the `except()` method
but from the compared object instead of the comparer one.
This way maybe has a too high performence cost, let me know what you think about this.